### PR TITLE
Fix enemies bug on tab changing

### DIFF
--- a/js/little/objects.js
+++ b/js/little/objects.js
@@ -41,6 +41,9 @@ var GameObj = {
     }
 
     this.update = function(deltaTime, blocks){
+      if(deltaTime > 30)
+        deltaTime = 16;
+
       for(i=0; i < blocks.length ; i++){
         if(this.checkColl(blocks[i])){
           if(this.dirX !== 0){


### PR DESCRIPTION
Resolve #2 

**Bug description:**
Enemies flash out of the map when changing tabs

**Fix description:**
Simply checked if `deltaTime` is greater than _30ms_, if so, sets it back to _16_ (may have impact on very low performance computers).